### PR TITLE
Add goreleaser + github action for it

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,38 @@
+name: "Release"
+
+on:
+  push:
+    tags:
+    - '**'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.19'
+
+      - name: Clean up dist directory
+        run: rm -rf dist
+
+      - name: Build
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: build --skip-validate
+
+      - name: Release
+        uses: goreleaser/goreleaser-action@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          version: latest
+          args: release --skip-validate --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 test/output.json
+

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -1,0 +1,28 @@
+project_name: juno-decode
+
+env:
+  # Require use of Go modules.
+  - GO111MODULE=on
+
+builds:
+  - id: "juno-decode"
+    main: ./main.go
+    ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+
+checksum:
+  name_template: SHA256SUMS-{{.Version}}.txt
+  algorithm: sha256
+
+release:
+  name_template: "Release {{.Version}}"
+
+archives:
+  - files:
+    - README.md
+


### PR DESCRIPTION
This is a proposition to add goreleaser.

The GH_TOKEN is a PAT (Personal Access Token) that is set as a environment secrets.

The end result is visible here: https://github.com/CharlesJUDITH/juno-decode/releases